### PR TITLE
Add local recipe images and display on index

### DIFF
--- a/images/guacamole.svg
+++ b/images/guacamole.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#abebc6"/>
+  <text x="400" y="300" font-size="48" font-family="Arial" text-anchor="middle" dominant-baseline="middle" fill="#145a32">Guacamole</text>
+</svg>

--- a/images/lasagna.svg
+++ b/images/lasagna.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#f9e79f"/>
+  <text x="400" y="300" font-size="48" font-family="Arial" text-anchor="middle" dominant-baseline="middle" fill="#c0392b">Lasagna</text>
+</svg>

--- a/images/pancakes.svg
+++ b/images/pancakes.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600">
+  <rect width="800" height="600" fill="#f5cba7"/>
+  <text x="400" y="300" font-size="48" font-family="Arial" text-anchor="middle" dominant-baseline="middle" fill="#6e2c00">Pancakes</text>
+</svg>

--- a/index.html
+++ b/index.html
@@ -10,9 +10,24 @@
     <h1>🍽️ Odin Recipes</h1>
     <p>Delicious, simple recipes to practice HTML & CSS!</p>
     <ul class="recipe-list">
-      <li><a href="recipes/lasagna.html">Classic Lasagna</a></li>
-      <li><a href="recipes/pancakes.html">Fluffy Pancakes</a></li>
-      <li><a href="recipes/guacamole.html">Fresh Guacamole</a></li>
+      <li>
+        <a href="recipes/lasagna.html">
+          <img src="images/lasagna.svg" alt="Classic Lasagna">
+          Classic Lasagna
+        </a>
+      </li>
+      <li>
+        <a href="recipes/pancakes.html">
+          <img src="images/pancakes.svg" alt="Fluffy Pancakes">
+          Fluffy Pancakes
+        </a>
+      </li>
+      <li>
+        <a href="recipes/guacamole.html">
+          <img src="images/guacamole.svg" alt="Fresh Guacamole">
+          Fresh Guacamole
+        </a>
+      </li>
     </ul>
   </div>
 </body>

--- a/recipes/guacamole.html
+++ b/recipes/guacamole.html
@@ -9,7 +9,7 @@
   <div class="container">
     <a class="back-link" href="../index.html">← Back to Recipes</a>
     <h1>Fresh Guacamole</h1>
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Guacamole.jpg/800px-Guacamole.jpg" alt="Fresh Guacamole">
+    <img src="../images/guacamole.svg" alt="Fresh Guacamole">
     
     <h2>Description</h2>
     <p>This fresh and simple guacamole is made with ripe avocados, lime juice, and flavorful additions. It's perfect for dipping, topping tacos, or eating straight off the spoon.</p>

--- a/recipes/lasagna.html
+++ b/recipes/lasagna.html
@@ -9,7 +9,7 @@
   <div class="container">
     <a class="back-link" href="../index.html">← Back to Recipes</a>
     <h1>Classic Lasagna</h1>
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/b/bc/Lasagna_%281%29.jpg/800px-Lasagna_%281%29.jpg" alt="Classic Lasagna">
+    <img src="../images/lasagna.svg" alt="Classic Lasagna">
     
     <h2>Description</h2>
     <p>This hearty lasagna is layered with rich meat sauce and three types of cheese, baked to perfection. A true comfort food favorite!</p>

--- a/recipes/pancakes.html
+++ b/recipes/pancakes.html
@@ -9,7 +9,7 @@
   <div class="container">
     <a class="back-link" href="../index.html">← Back to Recipes</a>
     <h1>Fluffy Pancakes</h1>
-    <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/3/3d/Pancakes_with_syrup.jpg/800px-Pancakes_with_syrup.jpg" alt="Fluffy Pancakes">
+    <img src="../images/pancakes.svg" alt="Fluffy Pancakes">
     
     <h2>Description</h2>
     <p>These pancakes are soft, thick, and fluffy — perfect for a cozy breakfast or brunch. Serve them with maple syrup, fruit, or your favorite toppings.</p>

--- a/styles.css
+++ b/styles.css
@@ -23,6 +23,9 @@ body {
     margin: 1rem 0;
   }
   .recipe-list a {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
     text-decoration: none;
     font-size: 1.2rem;
     color: #2980b9;
@@ -30,6 +33,9 @@ body {
   }
   .recipe-list a:hover {
     color: #e67e22;
+  }
+  .recipe-list img {
+    width: 300px;
   }
   img {
     max-width: 100%;


### PR DESCRIPTION
## Summary
- replace remote image links with local SVG files
- show recipe preview images on the index page
- style recipe list links to center images and text

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6892b07b47188324b126db02fe3e78a2